### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ mdtex2html
 markdownify
 srt
 peft
+google-generativeai


### PR DESCRIPTION
fix: `No module named 'google.generativeai'`

pip install google-generativeai