### PR TITLE
Fix GPT-5 compatibility by remapping max_tokens to max_completion_tokens

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -388,6 +388,20 @@ def ensure_version_suffix(base_url):
         base_url += 'v1/'
     return base_url
 
+def normalize_openai_chat_kwargs(kwargs):
+    normalized = dict(kwargs)
+    model_name = str(normalized.get("model", "") or "").strip().lower()
+
+    # GPT-5 chat/completions expects max_completion_tokens instead of max_tokens.
+    if model_name.startswith("gpt-5") and "max_completion_tokens" not in normalized and "max_tokens" in normalized:
+        normalized["max_completion_tokens"] = normalized.pop("max_tokens")
+
+    return normalized
+
+
+def create_openai_chat_completion(openai_client, **kwargs):
+    return openai_client.chat.completions.create(**normalize_openai_chat_kwargs(kwargs))
+
 class Chat:
     def __init__(self, model_name, apikey, baseurl) -> None:
         self.model_name = model_name
@@ -480,7 +494,7 @@ class Chat:
             print(history)
             reasoning_content = ""
             if tools is not None:
-                response = openai_client.chat.completions.create(
+                response = create_openai_chat_completion(openai_client, 
                     model=self.model_name,
                     messages=history,
                     temperature=temperature,
@@ -542,7 +556,7 @@ class Chat:
                                 "content": results,
                             }
                         )
-                        response = openai_client.chat.completions.create(
+                        response = create_openai_chat_completion(openai_client, 
                             model=self.model_name,
                             messages=history,
                             tools=tools,
@@ -607,7 +621,7 @@ class Chat:
                                 "content": results,
                             }
                         )
-                        response = openai_client.chat.completions.create(
+                        response = create_openai_chat_completion(openai_client, 
                             model=self.model_name,
                             messages=history,
                             tools=tools,
@@ -621,7 +635,7 @@ class Chat:
                         response_content = response.choices[0].message.content
                         print(response_content)
             elif is_tools_in_sys_prompt == "enable":
-                response = openai_client.chat.completions.create(
+                response = create_openai_chat_completion(openai_client, 
                     model=self.model_name,
                     messages=history,
                     temperature=temperature,
@@ -651,7 +665,7 @@ class Chat:
                             + "。请根据工具返回的结果继续回答我之前提出的问题。",
                         }
                     )
-                    response = openai_client.chat.completions.create(
+                    response = create_openai_chat_completion(openai_client, 
                         model=self.model_name,
                         messages=history,
                         temperature=temperature,
@@ -664,7 +678,7 @@ class Chat:
                     response_content = response.choices[0].message.content
                     print(response_content)
             else:
-                response = openai_client.chat.completions.create(
+                response = create_openai_chat_completion(openai_client, 
                     model=self.model_name,
                     messages=history,
                     temperature=temperature,
@@ -851,7 +865,7 @@ class aisuite_Chat:
             print(history)
             reasoning_content = ""
             if tools is not None:
-                response = openai_client.chat.completions.create(
+                response = create_openai_chat_completion(openai_client, 
                     model=self.model_name,
                     messages=history,
                     temperature=temperature,
@@ -913,7 +927,7 @@ class aisuite_Chat:
                                 "content": results,
                             }
                         )
-                        response = openai_client.chat.completions.create(
+                        response = create_openai_chat_completion(openai_client, 
                             model=self.model_name,
                             messages=history,
                             tools=tools,
@@ -978,7 +992,7 @@ class aisuite_Chat:
                                 "content": results,
                             }
                         )
-                        response = openai_client.chat.completions.create(
+                        response = create_openai_chat_completion(openai_client, 
                             model=self.model_name,
                             messages=history,
                             tools=tools,
@@ -992,7 +1006,7 @@ class aisuite_Chat:
                         response_content = response.choices[0].message.content
                         print(response_content)
             elif is_tools_in_sys_prompt == "enable":
-                response = openai_client.chat.completions.create(
+                response = create_openai_chat_completion(openai_client, 
                     model=self.model_name,
                     messages=history,
                     temperature=temperature,
@@ -1022,7 +1036,7 @@ class aisuite_Chat:
                             + "。请根据工具返回的结果继续回答我之前提出的问题。",
                         }
                     )
-                    response = openai_client.chat.completions.create(
+                    response = create_openai_chat_completion(openai_client, 
                         model=self.model_name,
                         messages=history,
                         temperature=temperature,
@@ -1035,7 +1049,7 @@ class aisuite_Chat:
                     response_content = response.choices[0].message.content
                     print(response_content)
             else:
-                response = openai_client.chat.completions.create(
+                response = create_openai_chat_completion(openai_client, 
                     model=self.model_name,
                     messages=history,
                     temperature=temperature,


### PR DESCRIPTION
## Summary
This PR adds a small compatibility layer for GPT-5 chat/completions calls.

`LLM` currently passes `max_tokens` for all OpenAI-compatible models. GPT-5 family models (`gpt-5*`) require `max_completion_tokens`.

## Changes
- Add `normalize_openai_chat_kwargs(kwargs)` in `llm.py`
- Add `create_openai_chat_completion(openai_client, **kwargs)` wrapper
- Route existing `openai_client.chat.completions.create(...)` call sites in `Chat.send` through the wrapper

Normalization rule:
- If model starts with `gpt-5`
- and `max_tokens` is present
- and `max_completion_tokens` is not present

then remap `max_tokens -> max_completion_tokens`.

## Why this is safe
- No behavior change for non-GPT-5 models.
- Backward-compatible with existing node params/UI.

## Validation
- `python -m py_compile llm.py`
- Verified call sites now use shared wrapper.

Closes #230
