### PR TITLE
Fix Show Text stale stacking: render latest item for list UI payload

### DIFF
--- a/tools/show_text.py
+++ b/tools/show_text.py
@@ -1,4 +1,13 @@
 class show_text_party:
+    @staticmethod
+    def _latest_scalar_text(value):
+        # UI should render only the latest item when list payloads are provided.
+        while isinstance(value, list) and len(value) > 0:
+            value = value[-1]
+        if value is None:
+            return ""
+        return str(value)
+
     @classmethod
     def INPUT_TYPES(s):
         return {
@@ -20,6 +29,7 @@ class show_text_party:
     CATEGORY = "大模型派对（llm_party）/文本（text）"
 
     def notify(self, text, unique_id=None, extra_pnginfo=None):
+        ui_text = self._latest_scalar_text(text)
         if unique_id is not None and extra_pnginfo is not None:
             if not isinstance(extra_pnginfo, list):
                 print("Error: extra_pnginfo is not a list")
@@ -35,9 +45,9 @@ class show_text_party:
                     None,
                 )
                 if node:
-                    node["widgets_values"] = [text]
+                    node["widgets_values"] = [ui_text]
 
-        return {"ui": {"text": text}, "result": (text,)}
+        return {"ui": {"text": [ui_text]}, "result": (text,)}
 
 
 class About_us:


### PR DESCRIPTION
## Summary
Focused fix for Show Text stale stacking when upstream provides list/nested-list `text` payloads.

## Root Cause
`show_text_party` is list-aware (`INPUT_IS_LIST=True`, `OUTPUT_IS_LIST=(True,)`).
When `text` arrives as a list, UI could render multiple historical blocks because widget/UI paths consumed the full list payload.

## Changes (single file)
`tools/show_text.py`:
- add `_latest_scalar_text(...)` helper,
- map list/nested-list input to the latest scalar item for UI display,
- write `widgets_values` using that scalar latest value,
- return `ui.text` as a single latest string item (`[ui_text]`),
- keep `result=(text,)` unchanged for graph compatibility.

## Validation
- local smoke:
  - `["ANALYSIS-7","ANALYSIS-8"]` -> UI `ANALYSIS-8`
  - `[["ANALYSIS-7"],["ANALYSIS-8"]]` -> UI `ANALYSIS-8`
  - scalar input remains unchanged.

Closes #232
