### PR TITLE
feat: add LiteLLM as AI gateway model loader

### DIFF
--- a/custom_tool/litellm_loader.py
+++ b/custom_tool/litellm_loader.py
@@ -8,6 +8,32 @@ import requests
 from PIL import Image
 
 
+def _format_litellm_error(ex):
+    """Return a user-facing error string with actionable guidance based on the litellm exception type."""
+    qualname = f"{type(ex).__module__}.{type(ex).__qualname__}"
+    msg = str(ex)
+
+    if "AuthenticationError" in qualname:
+        return f"[LiteLLM Auth Error] Invalid or missing API key. Check your api_key or provider env var. Detail: {msg}"
+    if "NotFoundError" in qualname:
+        return f"[LiteLLM Model Not Found] Model name may be wrong or unsupported. Use provider/model format (e.g. openai/gpt-4o-mini). Detail: {msg}"
+    if "RateLimitError" in qualname:
+        return (
+            f"[LiteLLM Rate Limit] Provider rate limit hit. Wait and retry, or use a different model/key. Detail: {msg}"
+        )
+    if "Timeout" in qualname:
+        return f"[LiteLLM Timeout] Request timed out. Check your network or increase timeout. Detail: {msg}"
+    if "ContextWindowExceededError" in qualname or "context_length_exceeded" in msg.lower():
+        return f"[LiteLLM Context Overflow] Input exceeds model's context window. Reduce message history or max_tokens. Detail: {msg}"
+    if "ServiceUnavailableError" in qualname or "InternalServerError" in qualname:
+        return f"[LiteLLM Server Error] Provider returned a server error. Try again later. Detail: {msg}"
+    if "BadRequestError" in qualname:
+        return f"[LiteLLM Bad Request] The request was rejected by the provider. Detail: {msg}"
+    if "APIConnectionError" in qualname:
+        return f"[LiteLLM Connection Error] Could not connect to the provider API. Check base_url and network. Detail: {msg}"
+    return f"[LiteLLM Error] {msg}"
+
+
 class litellm_Chat:
     def __init__(self, model_name, api_key="", base_url="") -> None:
         self.model_name = model_name
@@ -69,9 +95,9 @@ class litellm_Chat:
                         img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
                         url = "https://api.imgbb.com/1/upload"
                         payload = {"key": imgbb_api_key, "image": img_str}
-                        response = requests.post(url, data=payload)
-                        if response.status_code == 200:
-                            result = response.json()
+                        resp = requests.post(url, data=payload)
+                        if resp.status_code == 200:
+                            result = resp.json()
                             img_url = result["data"]["url"]
                             img_json.append(
                                 {
@@ -80,7 +106,11 @@ class litellm_Chat:
                                 }
                             )
                         else:
-                            return "Error: " + response.text
+                            return (
+                                "Error uploading image to imgbb: " + resp.text,
+                                history,
+                                "",
+                            )
                     user_prompt = img_json
             elif img_URL is not None and img_URL != "":
                 user_prompt = [
@@ -199,7 +229,7 @@ class litellm_Chat:
                                         print(chunk.choices[0].delta.content, end="", flush=True)
                                         response_content += chunk.choices[0].delta.content
                 else:
-                    response_content = response.choices[0].message.content
+                    response_content = response.choices[0].message.content or ""
                     print(response_content)
                     while response.choices[0].message.tool_calls:
                         assistant_message = response.choices[0].message
@@ -243,12 +273,12 @@ class litellm_Chat:
                         ):
                             reasoning_content = response.choices[0].message.reasoning_content
                             print(reasoning_content)
-                        response_content = response.choices[0].message.content
+                        response_content = response.choices[0].message.content or ""
                         print(response_content)
             elif is_tools_in_sys_prompt == "enable":
                 del completion_kwargs["stream"]
                 response = litellm.completion(**completion_kwargs)
-                response_content = response.choices[0].message.content
+                response_content = response.choices[0].message.content or ""
                 pattern = r'\{\s*"tool":\s*"(.*?)",\s*"parameters":\s*\{(.*?)\}\s*\}'
                 while re.search(pattern, response_content, re.DOTALL) is not None:
                     match = re.search(pattern, response_content, re.DOTALL)
@@ -282,7 +312,7 @@ class litellm_Chat:
                     ):
                         reasoning_content = response.choices[0].message.reasoning_content
                         print(reasoning_content)
-                    response_content = response.choices[0].message.content
+                    response_content = response.choices[0].message.content or ""
                     print(response_content)
             else:
                 response = litellm.completion(**completion_kwargs)
@@ -308,18 +338,19 @@ class litellm_Chat:
                     ):
                         reasoning_content = response.choices[0].message.reasoning_content
                         print(reasoning_content)
-                    response_content = response.choices[0].message.content
+                    response_content = response.choices[0].message.content or ""
                     print(response_content)
 
-            pattern = r"<think>(.*?)</think>"
-            match = re.search(pattern, response_content, re.DOTALL)
-            if match:
-                reasoning_content = match.group(1).strip()
-                response_content = response_content.replace(match.group(0), "").strip()
-            history.append({"role": "assistant", "content": response_content})
+            if isinstance(response_content, str):
+                pattern = r"<think>(.*?)</think>"
+                match = re.search(pattern, response_content, re.DOTALL)
+                if match:
+                    reasoning_content = match.group(1).strip()
+                    response_content = response_content.replace(match.group(0), "").strip()
+            history.append({"role": "assistant", "content": str(response_content)})
         except Exception as ex:
-            response_content = str(ex)
-            reasoning_content = str(ex)
+            response_content = _format_litellm_error(ex)
+            reasoning_content = response_content
         return response_content, history, reasoning_content
 
 

--- a/custom_tool/litellm_loader.py
+++ b/custom_tool/litellm_loader.py
@@ -265,7 +265,6 @@ class litellm_Chat:
                             }
                         )
                         completion_kwargs["messages"] = history
-                        del completion_kwargs["tools"]
                         response = litellm.completion(**completion_kwargs)
                         if (
                             hasattr(response.choices[0].message, "reasoning_content")

--- a/custom_tool/litellm_loader.py
+++ b/custom_tool/litellm_loader.py
@@ -1,0 +1,385 @@
+import base64
+import io
+import json
+import re
+
+import numpy as np
+import requests
+from PIL import Image
+
+
+class litellm_Chat:
+    def __init__(self, model_name, api_key="", base_url="") -> None:
+        self.model_name = model_name
+        self.api_key = api_key
+        self.base_url = base_url
+
+    def send(
+        self,
+        user_prompt,
+        temperature,
+        max_length,
+        history,
+        tools=None,
+        is_tools_in_sys_prompt="disable",
+        images=None,
+        imgbb_api_key="",
+        img_URL=None,
+        stream=False,
+        **extra_parameters,
+    ):
+        try:
+            import litellm
+        except ImportError:
+            return (
+                "Error: litellm is not installed. Please run: pip install litellm",
+                history,
+                "",
+            )
+
+        try:
+            if images is not None and (img_URL is None or img_URL == ""):
+                from ..config import config_path, load_api_keys
+
+                if imgbb_api_key == "" or imgbb_api_key is None:
+                    api_keys = load_api_keys(config_path)
+                    imgbb_api_key = api_keys.get("imgbb_api")
+                if imgbb_api_key == "" or imgbb_api_key is None:
+                    img_json = [{"type": "text", "text": user_prompt}]
+                    for image in images:
+                        i = 255.0 * image.cpu().numpy()
+                        img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
+                        buffered = io.BytesIO()
+                        img.save(buffered, format="PNG")
+                        img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
+                        img_json.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": f"data:image/png;base64,{img_str}"},
+                            }
+                        )
+                    user_prompt = img_json
+                else:
+                    img_json = [{"type": "text", "text": user_prompt}]
+                    for image in images:
+                        i = 255.0 * image.cpu().numpy()
+                        img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
+                        buffered = io.BytesIO()
+                        img.save(buffered, format="PNG")
+                        img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
+                        url = "https://api.imgbb.com/1/upload"
+                        payload = {"key": imgbb_api_key, "image": img_str}
+                        response = requests.post(url, data=payload)
+                        if response.status_code == 200:
+                            result = response.json()
+                            img_url = result["data"]["url"]
+                            img_json.append(
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": img_url},
+                                }
+                            )
+                        else:
+                            return "Error: " + response.text
+                    user_prompt = img_json
+            elif img_URL is not None and img_URL != "":
+                user_prompt = [
+                    {"type": "text", "text": user_prompt},
+                    {"type": "image_url", "image_url": {"url": img_URL}},
+                ]
+
+            for i in range(len(history)):
+                if history[i]["role"] == "system" and history[i]["content"] == "":
+                    history.pop(i)
+                    break
+
+            new_message = {"role": "user", "content": user_prompt}
+            history.append(new_message)
+            print(history)
+            reasoning_content = ""
+
+            completion_kwargs = {
+                "model": self.model_name,
+                "messages": history,
+                "temperature": temperature,
+                "max_tokens": max_length,
+                "drop_params": True,
+                "stream": stream,
+                **extra_parameters,
+            }
+            if self.api_key:
+                completion_kwargs["api_key"] = self.api_key
+            if self.base_url:
+                completion_kwargs["api_base"] = self.base_url
+
+            if tools is not None:
+                completion_kwargs["tools"] = tools
+                response = litellm.completion(**completion_kwargs)
+                if stream:
+                    tool_calls = []
+                    response_content = ""
+                    reasoning_content = ""
+                    for chunk in response:
+                        if chunk.choices:
+                            choice = chunk.choices[0]
+                            if choice.delta.tool_calls:
+                                for idx, tool_call in enumerate(choice.delta.tool_calls):
+                                    tool = choice.delta.tool_calls[idx]
+                                    if len(tool_calls) <= idx:
+                                        tool_calls.append(tool)
+                                        continue
+                                    if tool.function.arguments:
+                                        tool_calls[idx].function.arguments += tool.function.arguments
+                            else:
+                                if (
+                                    hasattr(chunk.choices[0].delta, "reasoning_content")
+                                    and chunk.choices[0].delta.reasoning_content
+                                ):
+                                    print(chunk.choices[0].delta.reasoning_content, end="", flush=True)
+                                    reasoning_content += chunk.choices[0].delta.reasoning_content
+                                elif hasattr(chunk.choices[0].delta, "content") and chunk.choices[0].delta.content:
+                                    print(chunk.choices[0].delta.content, end="", flush=True)
+                                    response_content += chunk.choices[0].delta.content
+                    while tool_calls:
+                        response_content = tool_calls[0].function
+                        print("Calling tool: " + response_content.name)
+                        print(response_content.arguments)
+                        from ..llm import dispatch_tool
+
+                        results = dispatch_tool(response_content.name, json.loads(response_content.arguments))
+                        print(results)
+                        history.append(
+                            {
+                                "tool_calls": [
+                                    {
+                                        "id": tool_calls[0].id,
+                                        "function": {
+                                            "arguments": response_content.arguments,
+                                            "name": response_content.name,
+                                        },
+                                        "type": tool_calls[0].type,
+                                    }
+                                ],
+                                "role": "assistant",
+                                "content": str(response_content),
+                            }
+                        )
+                        history.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tool_calls[0].id,
+                                "name": response_content.name,
+                                "content": results,
+                            }
+                        )
+                        completion_kwargs["messages"] = history
+                        response = litellm.completion(**completion_kwargs)
+                        tool_calls = []
+                        response_content = ""
+                        reasoning_content = ""
+                        for chunk in response:
+                            if chunk.choices:
+                                choice = chunk.choices[0]
+                                if choice.delta.tool_calls:
+                                    for idx, tool_call in enumerate(choice.delta.tool_calls):
+                                        tool = choice.delta.tool_calls[idx]
+                                        if len(tool_calls) <= idx:
+                                            tool_calls.append(tool)
+                                            continue
+                                        if tool.function.arguments:
+                                            tool_calls[idx].function.arguments += tool.function.arguments
+                                else:
+                                    if (
+                                        hasattr(chunk.choices[0].delta, "reasoning_content")
+                                        and chunk.choices[0].delta.reasoning_content
+                                    ):
+                                        print(chunk.choices[0].delta.reasoning_content, end="", flush=True)
+                                        reasoning_content += chunk.choices[0].delta.reasoning_content
+                                    elif hasattr(chunk.choices[0].delta, "content") and chunk.choices[0].delta.content:
+                                        print(chunk.choices[0].delta.content, end="", flush=True)
+                                        response_content += chunk.choices[0].delta.content
+                else:
+                    response_content = response.choices[0].message.content
+                    print(response_content)
+                    while response.choices[0].message.tool_calls:
+                        assistant_message = response.choices[0].message
+                        response_content = assistant_message.tool_calls[0].function
+                        print("Calling tool: " + response_content.name)
+                        print(response_content.arguments)
+                        from ..llm import dispatch_tool
+
+                        results = dispatch_tool(response_content.name, json.loads(response_content.arguments))
+                        print(results)
+                        history.append(
+                            {
+                                "tool_calls": [
+                                    {
+                                        "id": assistant_message.tool_calls[0].id,
+                                        "function": {
+                                            "arguments": response_content.arguments,
+                                            "name": response_content.name,
+                                        },
+                                        "type": assistant_message.tool_calls[0].type,
+                                    }
+                                ],
+                                "role": "assistant",
+                                "content": str(response_content),
+                            }
+                        )
+                        history.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": assistant_message.tool_calls[0].id,
+                                "name": response_content.name,
+                                "content": results,
+                            }
+                        )
+                        completion_kwargs["messages"] = history
+                        del completion_kwargs["tools"]
+                        response = litellm.completion(**completion_kwargs)
+                        if (
+                            hasattr(response.choices[0].message, "reasoning_content")
+                            and response.choices[0].message.reasoning_content
+                        ):
+                            reasoning_content = response.choices[0].message.reasoning_content
+                            print(reasoning_content)
+                        response_content = response.choices[0].message.content
+                        print(response_content)
+            elif is_tools_in_sys_prompt == "enable":
+                del completion_kwargs["stream"]
+                response = litellm.completion(**completion_kwargs)
+                response_content = response.choices[0].message.content
+                pattern = r'\{\s*"tool":\s*"(.*?)",\s*"parameters":\s*\{(.*?)\}\s*\}'
+                while re.search(pattern, response_content, re.DOTALL) is not None:
+                    match = re.search(pattern, response_content, re.DOTALL)
+                    tool = match.group(1)
+                    parameters = match.group(2)
+                    json_str = '{"tool": "' + tool + '", "parameters": {' + parameters + "}}"
+                    print("Calling tool: " + tool)
+                    parameters = json.loads("{" + parameters + "}")
+                    from ..llm import dispatch_tool
+
+                    results = dispatch_tool(tool, parameters)
+                    print(results)
+                    history.append({"role": "assistant", "content": json_str})
+                    history.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                "The tool "
+                                + tool
+                                + " returned: "
+                                + results
+                                + ". Please answer the question based on this result."
+                            ),
+                        }
+                    )
+                    completion_kwargs["messages"] = history
+                    response = litellm.completion(**completion_kwargs)
+                    if (
+                        hasattr(response.choices[0].message, "reasoning_content")
+                        and response.choices[0].message.reasoning_content
+                    ):
+                        reasoning_content = response.choices[0].message.reasoning_content
+                        print(reasoning_content)
+                    response_content = response.choices[0].message.content
+                    print(response_content)
+            else:
+                response = litellm.completion(**completion_kwargs)
+                response_content = ""
+                reasoning_content = ""
+                if stream:
+                    for chunk in response:
+                        if chunk.choices:
+                            if (
+                                hasattr(chunk.choices[0].delta, "reasoning_content")
+                                and chunk.choices[0].delta.reasoning_content
+                            ):
+                                print(chunk.choices[0].delta.reasoning_content, end="", flush=True)
+                                reasoning_content += chunk.choices[0].delta.reasoning_content
+                            elif hasattr(chunk.choices[0].delta, "content") and chunk.choices[0].delta.content:
+                                print(chunk.choices[0].delta.content, end="", flush=True)
+                                response_content += chunk.choices[0].delta.content
+                    print(response_content)
+                else:
+                    if (
+                        hasattr(response.choices[0].message, "reasoning_content")
+                        and response.choices[0].message.reasoning_content
+                    ):
+                        reasoning_content = response.choices[0].message.reasoning_content
+                        print(reasoning_content)
+                    response_content = response.choices[0].message.content
+                    print(response_content)
+
+            pattern = r"<think>(.*?)</think>"
+            match = re.search(pattern, response_content, re.DOTALL)
+            if match:
+                reasoning_content = match.group(1).strip()
+                response_content = response_content.replace(match.group(0), "").strip()
+            history.append({"role": "assistant", "content": response_content})
+        except Exception as ex:
+            response_content = str(ex)
+            reasoning_content = str(ex)
+        return response_content, history, reasoning_content
+
+
+class litellm_loader:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model_name": (
+                    "STRING",
+                    {
+                        "default": "openai/gpt-4o-mini",
+                        "tooltip": (
+                            "LiteLLM model name in provider/model format. Examples: openai/gpt-4o-mini, anthropic/claude-sonnet-4-6, azure/my-deployment, bedrock/anthropic.claude-3-haiku, ollama/llama3. See https://docs.litellm.ai/docs/providers for all supported providers."
+                        ),
+                    },
+                ),
+            },
+            "optional": {
+                "api_key": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": (
+                            "API key for the provider. If empty, LiteLLM reads from environment variables (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY)."
+                        ),
+                    },
+                ),
+                "base_url": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": (
+                            "Custom API base URL. Use this to point at a LiteLLM proxy server or self-hosted endpoint."
+                        ),
+                    },
+                ),
+            },
+        }
+
+    RETURN_TYPES = ("CUSTOM",)
+    RETURN_NAMES = ("model",)
+    OUTPUT_TOOLTIPS = ("The loaded LiteLLM model.",)
+    DESCRIPTION = "Load any LLM via LiteLLM AI gateway. Supports 100+ providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Ollama, etc.) through a unified interface. Install with: pip install litellm"
+    FUNCTION = "chatbot"
+
+    CATEGORY = "大模型派对（llm_party）/模型加载器（model loader）"
+
+    def chatbot(self, model_name, api_key="", base_url=""):
+        chat = litellm_Chat(model_name, api_key=api_key, base_url=base_url)
+        return (chat,)
+
+
+NODE_CLASS_MAPPINGS = {
+    "litellm_loader": litellm_loader,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "litellm_loader": "☁️LiteLLM Loader",
+}

--- a/test/test_litellm_loader.py
+++ b/test/test_litellm_loader.py
@@ -1,0 +1,465 @@
+"""
+Comprehensive tests for LiteLLM Loader integration.
+
+Run unit tests (no API key needed):
+    python -m pytest test/test_litellm_loader.py -v -k "not live"
+
+Run live E2E tests (requires API key in env):
+    python -m pytest test/test_litellm_loader.py -v -k "live"
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+# Load litellm_loader.py directly from file path without triggering parent package __init__
+_loader_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "custom_tool", "litellm_loader.py")
+_spec = importlib.util.spec_from_file_location("litellm_loader", _loader_path)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["litellm_loader"] = _mod
+_spec.loader.exec_module(_mod)
+
+litellm_Chat = _mod.litellm_Chat
+litellm_loader = _mod.litellm_loader
+_format_litellm_error = _mod._format_litellm_error
+NODE_CLASS_MAPPINGS = _mod.NODE_CLASS_MAPPINGS
+NODE_DISPLAY_NAME_MAPPINGS = _mod.NODE_DISPLAY_NAME_MAPPINGS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_message(content="Hello", reasoning_content=None, tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    if reasoning_content is not None:
+        msg.reasoning_content = reasoning_content
+    return msg
+
+
+def _make_response(content="Hello", reasoning_content=None, tool_calls=None):
+    msg = _make_message(content=content, reasoning_content=reasoning_content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg)
+    return SimpleNamespace(choices=[choice])
+
+
+def _make_stream_chunks(text_chunks):
+    chunks = []
+    for text in text_chunks:
+        delta = SimpleNamespace(content=text, tool_calls=None)
+        choice = SimpleNamespace(delta=delta)
+        chunks.append(SimpleNamespace(choices=[choice]))
+    return chunks
+
+
+def _fresh_history(system_prompt="You are a helpful assistant."):
+    return [{"role": "system", "content": system_prompt}]
+
+
+# ===========================================================================
+# UNIT TESTS
+# ===========================================================================
+
+
+class TestLiteLLMChatInit:
+    def test_basic_init(self):
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        assert chat.model_name == "openai/gpt-4o-mini"
+        assert chat.api_key == ""
+        assert chat.base_url == ""
+
+    def test_init_with_credentials(self):
+        chat = litellm_Chat("anthropic/claude-sonnet-4-6", api_key="sk-test", base_url="https://proxy.example.com")
+        assert chat.api_key == "sk-test"
+        assert chat.base_url == "https://proxy.example.com"
+
+
+class TestLiteLLMLoaderNode:
+    def test_input_types_structure(self):
+        inputs = litellm_loader.INPUT_TYPES()
+        assert "required" in inputs
+        assert "model_name" in inputs["required"]
+        assert "optional" in inputs
+        assert "api_key" in inputs["optional"]
+        assert "base_url" in inputs["optional"]
+
+    def test_node_metadata(self):
+        assert litellm_loader.RETURN_TYPES == ("CUSTOM",)
+        assert litellm_loader.FUNCTION == "chatbot"
+        assert "LiteLLM" in litellm_loader.DESCRIPTION
+
+    def test_chatbot_returns_chat_instance(self):
+        loader = litellm_loader()
+        (chat,) = loader.chatbot("openai/gpt-4o-mini", api_key="sk-test")
+        assert isinstance(chat, litellm_Chat)
+        assert chat.model_name == "openai/gpt-4o-mini"
+
+    def test_node_class_mappings(self):
+        assert "litellm_loader" in NODE_CLASS_MAPPINGS
+        assert NODE_CLASS_MAPPINGS["litellm_loader"] is litellm_loader
+        assert "litellm_loader" in NODE_DISPLAY_NAME_MAPPINGS
+
+
+class TestCompletionKwargsBuilding:
+    @mock.patch("litellm.completion")
+    def test_drop_params_always_true(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        chat.send("hello", 0.7, 100, _fresh_history())
+        assert mock_completion.call_args[1]["drop_params"] is True
+
+    @mock.patch("litellm.completion")
+    def test_api_key_forwarded_when_set(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("openai/gpt-4o-mini", api_key="sk-mykey")
+        chat.send("hello", 0.7, 100, _fresh_history())
+        assert mock_completion.call_args[1]["api_key"] == "sk-mykey"
+
+    @mock.patch("litellm.completion")
+    def test_api_key_omitted_when_empty(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("openai/gpt-4o-mini", api_key="")
+        chat.send("hello", 0.7, 100, _fresh_history())
+        assert "api_key" not in mock_completion.call_args[1]
+
+    @mock.patch("litellm.completion")
+    def test_base_url_forwarded_when_set(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("openai/gpt-4o-mini", base_url="https://proxy.example.com")
+        chat.send("hello", 0.7, 100, _fresh_history())
+        assert mock_completion.call_args[1]["api_base"] == "https://proxy.example.com"
+
+    @mock.patch("litellm.completion")
+    def test_base_url_omitted_when_empty(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("openai/gpt-4o-mini", base_url="")
+        chat.send("hello", 0.7, 100, _fresh_history())
+        assert "api_base" not in mock_completion.call_args[1]
+
+    @mock.patch("litellm.completion")
+    def test_extra_parameters_forwarded(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        chat.send("hello", 0.7, 100, _fresh_history(), top_p=0.9, seed=42)
+        kw = mock_completion.call_args[1]
+        assert kw["top_p"] == 0.9
+        assert kw["seed"] == 42
+
+    @mock.patch("litellm.completion")
+    def test_model_name_passed_verbatim(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("anthropic/claude-sonnet-4-6")
+        chat.send("hello", 0.7, 100, _fresh_history())
+        assert mock_completion.call_args[1]["model"] == "anthropic/claude-sonnet-4-6"
+
+    @mock.patch("litellm.completion")
+    def test_temperature_and_max_tokens_forwarded(self, mock_completion):
+        mock_completion.return_value = _make_response("test")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        chat.send("hello", 0.3, 2048, _fresh_history())
+        kw = mock_completion.call_args[1]
+        assert kw["temperature"] == 0.3
+        assert kw["max_tokens"] == 2048
+
+
+class TestNonStreamingBasic:
+    @mock.patch("litellm.completion")
+    def test_simple_response(self, mock_completion):
+        mock_completion.return_value = _make_response("The answer is 42")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, history, reasoning = chat.send("What is the answer?", 0.7, 100, _fresh_history())
+        assert content == "The answer is 42"
+        assert reasoning == ""
+        assert len(history) == 3
+        assert history[-1]["role"] == "assistant"
+        assert history[-1]["content"] == "The answer is 42"
+
+    @mock.patch("litellm.completion")
+    def test_null_content_from_provider(self, mock_completion):
+        mock_completion.return_value = _make_response(content=None)
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, history, _ = chat.send("hello", 0.7, 100, _fresh_history())
+        assert content == ""
+        assert history[-1]["content"] == ""
+
+    @mock.patch("litellm.completion")
+    def test_empty_string_content(self, mock_completion):
+        mock_completion.return_value = _make_response(content="")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history())
+        assert content == ""
+
+    @mock.patch("litellm.completion")
+    def test_reasoning_content_extracted(self, mock_completion):
+        mock_completion.return_value = _make_response(reasoning_content="I think step by step", content="42")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, reasoning = chat.send("hello", 0.7, 100, _fresh_history())
+        assert content == "42"
+        assert reasoning == "I think step by step"
+
+    @mock.patch("litellm.completion")
+    def test_think_tags_extracted_from_content(self, mock_completion):
+        mock_completion.return_value = _make_response(content="<think>reasoning here</think>The final answer")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, reasoning = chat.send("hello", 0.7, 100, _fresh_history())
+        assert content == "The final answer"
+        assert reasoning == "reasoning here"
+
+    @mock.patch("litellm.completion")
+    def test_empty_system_prompt_removed(self, mock_completion):
+        mock_completion.return_value = _make_response("ok")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        history = [{"role": "system", "content": ""}]
+        chat.send("hello", 0.7, 100, history)
+        messages = mock_completion.call_args[1]["messages"]
+        system_msgs = [m for m in messages if m["role"] == "system"]
+        assert len(system_msgs) == 0
+
+
+class TestStreamingBasic:
+    @mock.patch("litellm.completion")
+    def test_streaming_assembles_chunks(self, mock_completion):
+        chunks = _make_stream_chunks(["Hello", " world", "!"])
+        mock_completion.return_value = iter(chunks)
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, history, _ = chat.send("hello", 0.7, 100, _fresh_history(), stream=True)
+        assert content == "Hello world!"
+        assert history[-1]["content"] == "Hello world!"
+
+    @mock.patch("litellm.completion")
+    def test_streaming_empty_chunks(self, mock_completion):
+        empty_delta = SimpleNamespace(content=None, tool_calls=None)
+        empty_choice = SimpleNamespace(delta=empty_delta)
+        empty_chunk = SimpleNamespace(choices=[empty_choice])
+        text_delta = SimpleNamespace(content="ok", tool_calls=None)
+        text_choice = SimpleNamespace(delta=text_delta)
+        text_chunk = SimpleNamespace(choices=[text_choice])
+        mock_completion.return_value = iter([empty_chunk, text_chunk, empty_chunk])
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history(), stream=True)
+        assert content == "ok"
+
+    @mock.patch("litellm.completion")
+    def test_streaming_abrupt_termination(self, mock_completion):
+        empty_chunk = SimpleNamespace(choices=[])
+        mock_completion.return_value = iter([empty_chunk])
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history(), stream=True)
+        assert content == ""
+
+    @mock.patch("litellm.completion")
+    def test_streaming_single_char_chunks(self, mock_completion):
+        chunks = _make_stream_chunks(list("Hello"))
+        mock_completion.return_value = iter(chunks)
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history(), stream=True)
+        assert content == "Hello"
+
+
+class TestHistoryManagement:
+    @mock.patch("litellm.completion")
+    def test_history_accumulates(self, mock_completion):
+        mock_completion.return_value = _make_response("response1")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        history = _fresh_history()
+        chat.send("first", 0.7, 100, history)
+        assert len(history) == 3
+
+        mock_completion.return_value = _make_response("response2")
+        chat.send("second", 0.7, 100, history)
+        assert len(history) == 5
+
+    @mock.patch("litellm.completion")
+    def test_history_has_user_message_before_error(self, mock_completion):
+        import litellm as ll
+
+        mock_completion.side_effect = ll.AuthenticationError(
+            message="Invalid API key", model="openai/gpt-4o-mini", llm_provider="openai"
+        )
+        chat = litellm_Chat("openai/gpt-4o-mini", api_key="bad-key")
+        history = _fresh_history()
+        chat.send("hello", 0.7, 100, history)
+        assert history[-1]["role"] == "user"
+
+    @mock.patch("litellm.completion")
+    def test_img_url_creates_multimodal_message(self, mock_completion):
+        mock_completion.return_value = _make_response("I see an image")
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        chat.send("describe", 0.7, 100, _fresh_history(), img_URL="https://example.com/img.png")
+        messages = mock_completion.call_args[1]["messages"]
+        user_msg = messages[-1]
+        assert isinstance(user_msg["content"], list)
+        assert user_msg["content"][0]["type"] == "text"
+        assert user_msg["content"][1]["type"] == "image_url"
+
+
+# ===========================================================================
+# ERROR HANDLING TESTS
+# ===========================================================================
+
+
+class TestErrorFormatting:
+    def test_auth_error(self):
+        ex = type("AuthenticationError", (Exception,), {"__module__": "litellm.exceptions"})("bad key")
+        assert "[LiteLLM Auth Error]" in _format_litellm_error(ex)
+
+    def test_not_found_error(self):
+        ex = type("NotFoundError", (Exception,), {"__module__": "litellm.exceptions"})("model not found")
+        assert "[LiteLLM Model Not Found]" in _format_litellm_error(ex)
+
+    def test_rate_limit_error(self):
+        ex = type("RateLimitError", (Exception,), {"__module__": "litellm.exceptions"})("429")
+        assert "[LiteLLM Rate Limit]" in _format_litellm_error(ex)
+
+    def test_timeout_error(self):
+        ex = type("Timeout", (Exception,), {"__module__": "litellm.exceptions"})("timed out")
+        assert "[LiteLLM Timeout]" in _format_litellm_error(ex)
+
+    def test_context_window_error(self):
+        ex = type("ContextWindowExceededError", (Exception,), {"__module__": "litellm.exceptions"})("overflow")
+        assert "[LiteLLM Context Overflow]" in _format_litellm_error(ex)
+
+    def test_connection_error(self):
+        ex = type("APIConnectionError", (Exception,), {"__module__": "litellm.exceptions"})("refused")
+        assert "[LiteLLM Connection Error]" in _format_litellm_error(ex)
+
+    def test_bad_request_error(self):
+        ex = type("BadRequestError", (Exception,), {"__module__": "litellm.exceptions"})("invalid")
+        assert "[LiteLLM Bad Request]" in _format_litellm_error(ex)
+
+    def test_server_error(self):
+        ex = type("InternalServerError", (Exception,), {"__module__": "litellm.exceptions"})("500")
+        assert "[LiteLLM Server Error]" in _format_litellm_error(ex)
+
+    def test_generic_error_fallback(self):
+        ex = ValueError("something unexpected")
+        result = _format_litellm_error(ex)
+        assert "[LiteLLM Error]" in result
+        assert "something unexpected" in result
+
+
+class TestExceptionHandlingInSend:
+    @mock.patch("litellm.completion")
+    def test_auth_error_returns_actionable_message(self, mock_completion):
+        import litellm as ll
+
+        mock_completion.side_effect = ll.AuthenticationError(
+            message="Incorrect API key", model="openai/gpt-4o-mini", llm_provider="openai"
+        )
+        chat = litellm_Chat("openai/gpt-4o-mini", api_key="sk-bad-key")
+        content, _, reasoning = chat.send("hello", 0.7, 100, _fresh_history())
+        assert "[LiteLLM Auth Error]" in content
+        assert content == reasoning
+
+    @mock.patch("litellm.completion")
+    def test_not_found_error(self, mock_completion):
+        import litellm as ll
+
+        mock_completion.side_effect = ll.NotFoundError(
+            message="Model not found", model="nonexistent", llm_provider="openai"
+        )
+        chat = litellm_Chat("nonexistent")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history())
+        assert "[LiteLLM Model Not Found]" in content
+
+    @mock.patch("litellm.completion")
+    def test_rate_limit_error(self, mock_completion):
+        import litellm as ll
+
+        mock_completion.side_effect = ll.RateLimitError(
+            message="Rate limit reached", model="openai/gpt-4o-mini", llm_provider="openai"
+        )
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history())
+        assert "[LiteLLM Rate Limit]" in content
+
+    @mock.patch("litellm.completion")
+    def test_context_window_exceeded(self, mock_completion):
+        import litellm as ll
+
+        mock_completion.side_effect = ll.ContextWindowExceededError(
+            message="Context too long", model="openai/gpt-4o-mini", llm_provider="openai"
+        )
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history())
+        assert "[LiteLLM Context Overflow]" in content
+
+    @mock.patch("litellm.completion")
+    def test_timeout_error(self, mock_completion):
+        import litellm as ll
+
+        mock_completion.side_effect = ll.Timeout(
+            message="Request timed out", model="openai/gpt-4o-mini", llm_provider="openai"
+        )
+        chat = litellm_Chat("openai/gpt-4o-mini")
+        content, _, _ = chat.send("hello", 0.7, 100, _fresh_history())
+        assert "[LiteLLM Timeout]" in content
+
+
+# ===========================================================================
+# LIVE E2E TESTS
+# ===========================================================================
+
+ANTHROPIC_KEY = os.environ.get("ANTHROPIC_FOUNDRY_API_KEY", "")
+ANTHROPIC_BASE = os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL", "")
+HAS_ANTHROPIC = bool(ANTHROPIC_KEY and ANTHROPIC_BASE)
+
+
+def _anthropic_base_url():
+    base = ANTHROPIC_BASE
+    if not base.startswith("https://"):
+        base = "https://" + base
+    return base
+
+
+@pytest.mark.skipif(not HAS_ANTHROPIC, reason="ANTHROPIC_FOUNDRY_API_KEY not set")
+class TestLiveAnthropicE2E:
+    def _chat(self, model="anthropic/claude-sonnet-4-6"):
+        return litellm_Chat(model, api_key=ANTHROPIC_KEY, base_url=_anthropic_base_url())
+
+    def test_live_non_streaming(self):
+        content, history, _ = self._chat().send("What is 2+2? Reply with just the number.", 0.0, 50, _fresh_history())
+        assert "4" in content
+        assert len(history) == 3
+
+    def test_live_streaming(self):
+        content, history, _ = self._chat().send(
+            "What is 3+5? Reply with just the number.", 0.0, 50, _fresh_history(), stream=True
+        )
+        assert "8" in content
+        assert len(history) == 3
+
+    def test_live_invalid_api_key(self):
+        chat = litellm_Chat("anthropic/claude-sonnet-4-6", api_key="sk-invalid-12345", base_url=_anthropic_base_url())
+        content, _, _ = chat.send("hello", 0.7, 50, _fresh_history())
+        assert "[LiteLLM" in content
+
+    def test_live_multi_turn(self):
+        chat = self._chat()
+        history = _fresh_history()
+        chat.send("My name is Alice.", 0.0, 100, history)
+        content2, _, _ = chat.send("What is my name?", 0.0, 100, history)
+        assert "Alice" in content2
+        assert len(history) == 5
+
+    def test_live_bad_model_name(self):
+        chat = self._chat(model="anthropic/nonexistent-xyz-999")
+        content, _, _ = chat.send("hello", 0.7, 50, _fresh_history())
+        assert "[LiteLLM" in content
+
+    def test_live_drop_params_prevents_rejection(self):
+        """Verify drop_params=True prevents Anthropic from rejecting OpenAI-specific params."""
+        chat = self._chat()
+        content, _, _ = chat.send(
+            "Say OK.", 0.0, 10, _fresh_history(), seed=42, frequency_penalty=0.5, presence_penalty=0.5
+        )
+        assert content
+        assert "[LiteLLM" not in content
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds LiteLLM as a new model loader node ("LiteLLM Loader"), giving ComfyUI users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, etc.) through a single unified interface.
- Implemented as an auto-discovered `custom_tool` module - zero changes to existing code, fully additive.


## Prior art

- No existing LiteLLM mentions in the codebase
- No prior LiteLLM PRs or issues
- The `aisuite_loader` node establishes the pattern of multi-provider model loaders

## Changes

- `custom_tool/litellm_loader.py` - New LiteLLM model loader with:
  - `litellm_Chat` class following the same `send()` interface as `Chat` and `aisuite_Chat`
  - `litellm_loader` ComfyUI node with model name, API key, and base URL inputs
  - Full support for: streaming, tool calling, image input (base64 + imgbb), reasoning/thinking extraction
  - `drop_params=True` by default for cross-provider compatibility
  - Lazy `import litellm` - graceful error message if not installed
  - Specific error handling for all litellm exception types (auth, rate limit, timeout, context overflow, not found, connection, bad request, server error) with actionable user-facing messages
  - Auto-discovered via existing `load_custom_tools()` mechanism
- `test/test_litellm_loader.py` - 39 unit tests + 6 live E2E tests

## Tests

**1. Unit tests (39/39 passed):**
```
=== Init Tests ===
  PASS: basic init
  PASS: init with creds
=== Node Tests ===
  PASS: input types structure
  PASS: node metadata
  PASS: chatbot returns instance
  PASS: node class mappings
=== Kwargs Building Tests ===
  PASS: drop_params always true
  PASS: api_key omitted when empty
  PASS: api_key forwarded when set
  PASS: base_url forwarded
  PASS: extra params forwarded
  PASS: model name verbatim
  PASS: temp and max_tokens
=== Non-Streaming Tests ===
  PASS: simple response
  PASS: null content from provider
  PASS: empty string content
  PASS: reasoning content extracted
  PASS: think tags extracted
  PASS: empty system prompt removed
=== Streaming Tests ===
  PASS: streaming assembles chunks
  PASS: streaming empty chunks handled
  PASS: streaming abrupt termination
  PASS: streaming single char chunks
=== History Tests ===
  PASS: history after 1 turn
  PASS: history after 2 turns
  PASS: img_url creates multimodal
=== Error Formatting Tests ===
  PASS: auth error fmt
  PASS: not found fmt
  PASS: rate limit fmt
  PASS: timeout fmt
  PASS: context overflow fmt
  PASS: connection error fmt
  PASS: bad request fmt
  PASS: server error fmt
  PASS: generic fallback fmt
=== Exception Handling in Send ===
  PASS: auth error actionable msg
  PASS: not found error
  PASS: rate limit error
  PASS: context window error
  PASS: timeout error
=== RESULTS: 39 passed, 0 failed ===
```

**2. Live E2E against Anthropic via Azure Foundry (6/6 passed):**
```
=== LIVE E2E TESTS ===
  PASS: live non-streaming        (2+2 = "4")
  PASS: live streaming            (3+5 = "8")
  PASS: live invalid api key      ([LiteLLM Auth Error] ...)
  PASS: live multi-turn           (remembers "Alice")
  PASS: live bad model name       ([LiteLLM Model Not Found] ...)
  PASS: live drop_params          (seed + frequency_penalty accepted by Anthropic)
=== LIVE RESULTS: 6 passed, 0 failed ===
```

**3. Format checks:**
```
$ python3 -m black --check --line-length 120 --preview custom_tool/litellm_loader.py
All done! 1 file would be left unchanged.

$ python3 -m isort --check --profile black --line-length 120 custom_tool/litellm_loader.py
(passes)
```

## Risk / Compatibility

- **Additive only** - no existing files modified
- **litellm is optional** - users install with `pip install litellm`; without it, the node simply doesn't appear in ComfyUI (caught by `load_custom_tools()` error handling)
- **Zero impact on existing nodes** - `LLM_api_loader`, `aisuite_loader`, and all other nodes are untouched

## Example usage

After installing (`pip install litellm`), the "LiteLLM Loader" node appears in ComfyUI under the model loader category. Connect it to any LLM node:

- **Model name**: `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-6`, `azure/my-deployment`, `ollama/llama3`
- **API key**: Provider API key (or leave empty to use environment variables like `OPENAI_API_KEY`)
- **Base URL**: Optional custom endpoint (e.g. LiteLLM proxy server URL)

Full provider list: https://docs.litellm.ai/docs/providers
