### PR TITLE
fix: improve seed parameter in extra_parameters node

### DIFF
--- a/custom_tool/extra_parameters.py
+++ b/custom_tool/extra_parameters.py
@@ -19,7 +19,7 @@ class extra_parameters:
                 "user": ("STRING", {"default": ""}),
                 "top_p": ("FLOAT", {"default": 1.0,"min": 0.0, "max": 1.0,"step": 0.1}),
                 "top_k": ("INT", {"default": 50}),
-                "seed": ("INT", {"default": 42}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 999999999, "step": 1}),
             }
         }
 
@@ -45,7 +45,7 @@ class extra_parameters:
         top_k=50,
         min_length=0,
         repetition_penalty=1.0,
-        seed=42,
+        seed=-1,
     ):
         json_data = {}
         if top_p != 1.0:
@@ -74,7 +74,7 @@ class extra_parameters:
             json_data["min_length"] = min_length
         if repetition_penalty != 1.0:
             json_data["repetition_penalty"] = repetition_penalty
-        if seed != 42:
+        if seed >= 0:
             json_data["seed"] = seed
 
         return (json_data,)


### PR DESCRIPTION
- Change seed default from 42 to -1 (consistent with LLM node)
- Add min/max/step constraints to seed widget
- Change sentinel check from '!= 42' to '>= 0' so seed=42 works

Previously the seed parameter used 42 as a sentinel value for 'not set', which meant users couldn't actually set seed=42. The LLM node already uses -1 as the sentinel; this aligns extra_parameters with the same convention.

Closes #76, #178, #238
Related: #191