### PR TITLE
Add Atlas Cloud preset for LLM API loader

### DIFF
--- a/atlascloud_config.py
+++ b/atlascloud_config.py
@@ -1,0 +1,67 @@
+import os
+
+
+ATLASCLOUD_DEFAULT_BASE_URL = "https://api.atlascloud.ai/v1/"
+ATLASCLOUD_DEFAULT_MODEL = "qwen/qwen3.5-flash"
+ATLASCLOUD_REASONING_MODEL = "deepseek-ai/deepseek-v4-pro"
+ATLASCLOUD_MODEL_ALIASES = {"atlas", "atlascloud", "atlas-cloud"}
+ATLASCLOUD_MODEL_PREFIXES = ("atlas/", "atlascloud/", "atlas-cloud/")
+
+
+def resolve_env_reference(value, environ=None):
+    if value is None:
+        return ""
+    value = str(value).strip()
+    if not value.startswith("env:"):
+        return value
+
+    environ = environ or os.environ
+    return environ.get(value[4:].strip(), "")
+
+
+def get_atlascloud_api_key(environ=None):
+    environ = environ or os.environ
+    return environ.get("ATLASCLOUD_API_KEY") or environ.get("ATLAS_CLOUD_API_KEY") or ""
+
+
+def get_atlascloud_base_url(environ=None):
+    environ = environ or os.environ
+    return (
+        environ.get("ATLASCLOUD_API_BASE")
+        or environ.get("ATLAS_CLOUD_API_BASE")
+        or ATLASCLOUD_DEFAULT_BASE_URL
+    )
+
+
+def is_atlascloud_base_url(base_url):
+    return "api.atlascloud.ai" in str(base_url or "").lower()
+
+
+def is_atlascloud_model_alias(model_name):
+    normalized = str(model_name or "").strip().lower()
+    return normalized in ATLASCLOUD_MODEL_ALIASES or normalized.startswith(ATLASCLOUD_MODEL_PREFIXES)
+
+
+def resolve_atlascloud_model_name(model_name):
+    value = str(model_name or "").strip()
+    normalized = value.lower()
+    if normalized in ATLASCLOUD_MODEL_ALIASES:
+        return ATLASCLOUD_DEFAULT_MODEL
+    for prefix in ATLASCLOUD_MODEL_PREFIXES:
+        if normalized.startswith(prefix):
+            return value[len(prefix) :]
+    return value
+
+
+def resolve_atlascloud_request(model_name, api_key="", base_url="", environ=None):
+    environ = environ or os.environ
+    uses_atlascloud = is_atlascloud_model_alias(model_name) or is_atlascloud_base_url(base_url)
+    model_name = resolve_atlascloud_model_name(model_name)
+    api_key = resolve_env_reference(api_key, environ)
+    base_url = resolve_env_reference(base_url, environ)
+
+    if uses_atlascloud or is_atlascloud_base_url(base_url):
+        api_key = api_key or get_atlascloud_api_key(environ)
+        base_url = base_url or get_atlascloud_base_url(environ)
+
+    return model_name, api_key, base_url

--- a/config.ini.example
+++ b/config.ini.example
@@ -43,6 +43,16 @@ api_key=
 base_url=https://ark.cn-beijing.volces.com/api/v3/
 api_key=
 
+[atlascloud]
+base_url=https://api.atlascloud.ai/v1/
+api_key=env:ATLASCLOUD_API_KEY
+model_name=qwen/qwen3.5-flash
+
+[atlascloud-reasoning]
+base_url=https://api.atlascloud.ai/v1/
+api_key=env:ATLASCLOUD_API_KEY
+model_name=deepseek-ai/deepseek-v4-pro
+
 [your_ollama_model_name]
 base_url=http://127.0.0.1:11434/v1/
 api_key=ollama

--- a/config_update.py
+++ b/config_update.py
@@ -6,6 +6,7 @@ import openai
 import server
 from aiohttp import web
 from .config import load_api_keys
+from .atlascloud_config import resolve_atlascloud_request, resolve_env_reference
 import subprocess
 import sys
 import asyncio
@@ -14,8 +15,9 @@ import json
 
 config_path = os.path.join(os.path.dirname(__file__), 'config.ini')
 llm_api_keys = load_api_keys(config_path)
-llm_api_key=llm_api_keys.get("openai_api_key", "").strip()
-llm_base_url=llm_api_keys.get("base_url", "").strip()
+llm_api_key=resolve_env_reference(llm_api_keys.get("openai_api_key", "").strip())
+llm_base_url=resolve_env_reference(llm_api_keys.get("base_url", "").strip())
+_, llm_api_key, llm_base_url = resolve_atlascloud_request("", llm_api_key, llm_base_url)
 if llm_api_key == "" or llm_api_key =="sk-XXXXX" or llm_base_url == "":
     models_dict =[]
 else:
@@ -49,8 +51,9 @@ async def update_config(request):
         with open(config_path, 'w') as configfile:
             config.write(configfile)
         llm_api_keys = load_api_keys(config_path)
-        llm_api_key=llm_api_keys.get("openai_api_key").strip()
-        llm_base_url=llm_api_keys.get("base_url").strip()
+        llm_api_key=resolve_env_reference(llm_api_keys.get("openai_api_key").strip())
+        llm_base_url=resolve_env_reference(llm_api_keys.get("base_url").strip())
+        _, llm_api_key, llm_base_url = resolve_atlascloud_request("", llm_api_key, llm_base_url)
         global models_dict
         if llm_api_key == "" or llm_api_key =="sk-XXXXX" or llm_base_url == "":
             models_dict =[]

--- a/llm.py
+++ b/llm.py
@@ -40,6 +40,12 @@ if torch.cuda.is_available():
     from transformers import BitsAndBytesConfig
 from google.protobuf.struct_pb2 import Struct
 from torchvision.transforms import ToPILImage
+from .atlascloud_config import (
+    is_atlascloud_base_url,
+    is_atlascloud_model_alias,
+    resolve_atlascloud_request,
+    resolve_env_reference,
+)
 from .config_update import models_dict
 from .config import config_key, config_path, current_dir_path, load_api_keys
 from .tools.lorebook import Lorebook
@@ -417,11 +423,13 @@ async def get_models_list(api_key: str, base_url: str) -> tuple[list[str], int |
     - error_status_code is None if successful
     - error_status_code is the HTTP status code if failed
     """
+    _, api_key, base_url = resolve_atlascloud_request("", api_key, base_url)
+
     print(f"[LLM Party] === get_models_list Called ===")
     print(f"[LLM Party] api_key provided: {bool(api_key)}")
     print(f"[LLM Party] base_url: '{base_url}'")
 
-    url = f"{base_url}/models"
+    url = f"{str(base_url).rstrip('/')}/models"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
@@ -1245,6 +1253,9 @@ class LLM_api_loader:
     CATEGORY = "大模型派对（llm_party）/模型加载器（model loader）"
 
     def chatbot(self, model_name, base_url=None, api_key=None, is_ollama=False):
+        base_url = base_url or ""
+        api_key = api_key or ""
+
         if "api.perplexity.ai" in (base_url or ""):
             # For Perplexity API, simplify the base URL
             openai.base_url = ensure_version_suffix(base_url)
@@ -1253,26 +1264,43 @@ class LLM_api_loader:
         elif is_ollama:
             openai.api_key = "ollama"
             openai.base_url = "http://127.0.0.1:11434/v1/"
+        elif is_atlascloud_model_alias(model_name) or is_atlascloud_base_url(base_url):
+            if model_name in config_key:
+                api_keys = config_key[model_name]
+                model_name = api_keys.get("model_name", model_name).strip() or model_name
+                api_key = api_key or api_keys.get("api_key", "")
+                base_url = base_url or api_keys.get("base_url", "")
+            model_name, openai.api_key, openai.base_url = resolve_atlascloud_request(
+                model_name,
+                api_key,
+                base_url,
+            )
         else:
             api_keys = load_api_keys(config_path)
+            model_config = config_key[model_name] if model_name in config_key else None
             if api_key != "":
-                openai.api_key = api_key
-            elif model_name in config_key:
-                api_keys = config_key[model_name]
-                openai.api_key = api_keys.get("api_key")
+                openai.api_key = resolve_env_reference(api_key)
+            elif model_config is not None:
+                openai.api_key = resolve_env_reference(model_config.get("api_key"))
             elif api_keys.get("openai_api_key") != "":
-                openai.api_key = api_keys.get("openai_api_key")
+                openai.api_key = resolve_env_reference(api_keys.get("openai_api_key"))
             if base_url != "":
-                openai.base_url = base_url
-            elif model_name in config_key:
-                api_keys = config_key[model_name]
-                openai.base_url = api_keys.get("base_url")
+                openai.base_url = resolve_env_reference(base_url)
+            elif model_config is not None:
+                openai.base_url = resolve_env_reference(model_config.get("base_url"))
             elif api_keys.get("base_url") != "":
-                openai.base_url = api_keys.get("base_url")
+                openai.base_url = resolve_env_reference(api_keys.get("base_url"))
+            if model_config is not None:
+                model_name = model_config.get("model_name", model_name).strip() or model_name
+            model_name, openai.api_key, openai.base_url = resolve_atlascloud_request(
+                model_name,
+                openai.api_key,
+                openai.base_url,
+            )
             if openai.api_key == "":
                 api_keys = load_api_keys(config_path)
-                openai.api_key = api_keys.get("openai_api_key")
-                openai.base_url = api_keys.get("base_url")
+                openai.api_key = resolve_env_reference(api_keys.get("openai_api_key"))
+                openai.base_url = resolve_env_reference(api_keys.get("base_url"))
             if openai.base_url != "" and "api.perplexity.ai" not in openai.base_url:
                 if openai.base_url[-1] != "/":
                     openai.base_url = openai.base_url + "/"

--- a/test/test_atlascloud_config.py
+++ b/test/test_atlascloud_config.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import atlascloud_config as atlascloud
+
+
+def test_resolves_atlascloud_alias_to_default_model_and_env_key():
+    env = {"ATLASCLOUD_API_KEY": "test-key"}
+
+    model, api_key, base_url = atlascloud.resolve_atlascloud_request("atlascloud", environ=env)
+
+    assert model == "qwen/qwen3.5-flash"
+    assert api_key == "test-key"
+    assert base_url == "https://api.atlascloud.ai/v1/"
+
+
+def test_resolves_prefixed_atlascloud_model_without_rewriting_model_id():
+    env = {"ATLASCLOUD_API_KEY": "test-key"}
+
+    model, api_key, base_url = atlascloud.resolve_atlascloud_request(
+        "atlascloud/deepseek-ai/deepseek-v4-pro",
+        environ=env,
+    )
+
+    assert model == "deepseek-ai/deepseek-v4-pro"
+    assert api_key == "test-key"
+    assert base_url == "https://api.atlascloud.ai/v1/"
+
+
+def test_atlascloud_base_url_uses_env_key_when_key_is_empty():
+    env = {"ATLAS_CLOUD_API_KEY": "fallback-key"}
+
+    model, api_key, base_url = atlascloud.resolve_atlascloud_request(
+        "qwen/qwen3.5-flash",
+        base_url="https://api.atlascloud.ai/v1/",
+        environ=env,
+    )
+
+    assert model == "qwen/qwen3.5-flash"
+    assert api_key == "fallback-key"
+    assert base_url == "https://api.atlascloud.ai/v1/"
+
+
+def test_env_reference_resolution():
+    env = {"ATLASCLOUD_API_KEY": "test-key"}
+
+    assert atlascloud.resolve_env_reference("env:ATLASCLOUD_API_KEY", env) == "test-key"
+
+
+if __name__ == "__main__":
+    test_resolves_atlascloud_alias_to_default_model_and_env_key()
+    test_resolves_prefixed_atlascloud_model_without_rewriting_model_id()
+    test_atlascloud_base_url_uses_env_key_when_key_is_empty()
+    test_env_reference_resolution()


### PR DESCRIPTION
## Summary
- Add an Atlas Cloud OpenAI-compatible helper for model aliases, base URL defaults, and `ATLASCLOUD_API_KEY` / `ATLAS_CLOUD_API_KEY` environment variable resolution.
- Add `atlascloud` and `atlascloud-reasoning` presets to `config.ini.example` using `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.
- Wire Atlas base URL handling into model refresh and the existing `LLM_api_loader`, without changing README or branding sections.

## Validation
- `python3 test/test_atlascloud_config.py`
- `python3 -m compileall -q atlascloud_config.py config_update.py llm.py test/test_atlascloud_config.py`
- `git diff --check`
- Parsed `config.ini.example` and verified the two Atlas preset sections.
- Live Atlas `/v1/models` check returned 120 models and confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.

## Note
`python3 -m pytest test/test_atlascloud_config.py -q` still imports the ComfyUI package bootstrap first in a standalone checkout and requires ComfyUI's `server` module, so the focused helper test is also runnable directly as shown above.