### PR TITLE
feat: 新增 Tavily 搜索节点 + 异步 LLM Pipeline 节点 + 修复 DeepSeek 思考模式 400 错误

### DIFF
--- a/custom_tool/README_pipeline.md
+++ b/custom_tool/README_pipeline.md
@@ -1,0 +1,11 @@
+# API LLM Pipeline
+
+节点名：`☁️API LLM Pipeline（上一轮输出）`
+
+它复用 `☁️API LLM general link` 的 `LLM.chatbot()`，因此保留相同的 Loader、记忆、工具、图像、文件、历史、额外参数、流式输出和五路标准输出；额外增加 `pipeline_status`。
+
+- 第一次运行使用原始用户提示词，同时后台生成第一条 LLM 输出。
+- 第二次运行使用第一条输出，同时后台生成第二条。
+- `pipeline_reset` 加 1 会清空 Pipeline 缓存及其会话实例。
+- 后台尚未完成时重复 Queue，只保留最新的待处理输入。
+- LLM 最终回答为空时保留上一轮成功输出，避免 `max_length` 截断导致提示词消失。

--- a/custom_tool/pipeline_llm.py
+++ b/custom_tool/pipeline_llm.py
@@ -1,0 +1,292 @@
+"""One-run-delayed pipeline wrapper for LLM Party's API LLM node."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from typing import Any, Dict, Optional, Tuple
+
+
+_STATES: Dict[str, Dict[str, Any]] = {}
+_LOCK = threading.RLock()
+
+
+def _history_choices():
+    temp_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "temp")
+    try:
+        paths = [os.path.join(temp_path, name) for name in os.listdir(temp_path)]
+        paths = [path for path in paths if os.path.isfile(path)]
+        paths.sort(key=os.path.getmtime, reverse=True)
+        return [""] + [os.path.basename(path) for path in paths]
+    except OSError:
+        return [""]
+
+
+def _new_state(reset_counter: int) -> Dict[str, Any]:
+    return {
+        "ready": None,
+        "ready_seq": 0,
+        "running": False,
+        "pending": None,
+        "delegate": None,
+        "error": "",
+        "version": 0,
+        "last_reset": reset_counter,
+    }
+
+
+def _create_delegate(model):
+    """Find the owning llm.py module and instantiate its original LLM node."""
+    module_name = model.__class__.__module__
+    module = sys.modules.get(module_name)
+    llm_class = getattr(module, "LLM", None) if module is not None else None
+    if llm_class is None:
+        raise RuntimeError(
+            "无法定位 comfyui_LLM_party.llm.LLM；请使用本插件的 ☁️API LLM Loader 输出"
+        )
+    return llm_class()
+
+
+def _clone_images_to_cpu(images):
+    """Detach queued image input from GPU work before the background request starts."""
+    if images is None:
+        return None
+    try:
+        return images.detach().cpu().clone()
+    except AttributeError:
+        return images
+
+
+def _validate_result(result) -> Tuple[Any, Any, Any, Any, Any]:
+    if not isinstance(result, (tuple, list)) or len(result) != 5:
+        raise RuntimeError("原 LLM 节点返回了无效结果，预期为 5 路输出")
+    response, history, tool, image, reasoning = result
+    if response is None:
+        raise RuntimeError("原 LLM 节点没有返回 assistant_response")
+    if not str(response).strip() and str(reasoning or "").strip():
+        raise RuntimeError("LLM 只返回了推理内容而没有最终回答；请提高 max_length")
+    if not str(response).strip():
+        raise RuntimeError("LLM 最终回答为空；保留上一轮输出")
+    return response, history, tool, image, reasoning
+
+
+def _worker(state_key: str):
+    while True:
+        with _LOCK:
+            state = _STATES.get(state_key)
+            if state is None:
+                return
+            payload = state["pending"]
+            state["pending"] = None
+            if payload is None:
+                state["running"] = False
+                return
+            version = state["version"]
+            delegate = state["delegate"]
+
+        try:
+            if delegate is None:
+                delegate = _create_delegate(payload["model"])
+                with _LOCK:
+                    state = _STATES.get(state_key)
+                    if state is None:
+                        return
+                    if state["version"] == version:
+                        state["delegate"] = delegate
+            result = _validate_result(delegate.chatbot(**payload))
+            error: Optional[str] = None
+        except Exception as exc:
+            result = None
+            error = str(exc)
+
+        with _LOCK:
+            state = _STATES.get(state_key)
+            if state is None:
+                return
+            if state["version"] == version:
+                if result is not None:
+                    state["ready"] = result
+                    state["ready_seq"] += 1
+                    state["error"] = ""
+                else:
+                    state["error"] = error or "未知错误"
+            if state["pending"] is None:
+                state["running"] = False
+                return
+
+
+def _start_worker(state_key: str):
+    threading.Thread(
+        target=_worker,
+        args=(state_key,),
+        name=f"llm-party-pipeline-{state_key}",
+        daemon=True,
+    ).start()
+
+
+class LLMPartyPipeline:
+    """Reuse all LLM Party behavior while moving the next request to a background thread."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "system_prompt": ("STRING", {"multiline": True, "default": "你是一个强大的人工智能助手。"}),
+                "user_prompt": ("STRING", {"multiline": True, "default": "你好"}),
+                "model": ("CUSTOM",),
+                "temperature": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 1.0, "step": 0.1}),
+                "is_memory": (["enable", "disable"], {"default": "disable"}),
+                "is_tools_in_sys_prompt": (["enable", "disable"], {"default": "disable"}),
+                "is_locked": (["enable", "disable"], {"default": "disable"}),
+                "main_brain": (["enable", "disable"], {"default": "enable"}),
+                "max_length": ("INT", {"default": 1920, "min": 256, "max": 128000, "step": 128}),
+            },
+            "optional": {
+                "system_prompt_input": ("STRING", {"forceInput": True}),
+                "user_prompt_input": ("STRING", {"forceInput": True}),
+                "tools": ("STRING", {"forceInput": True}),
+                "file_content": ("STRING", {"forceInput": True}),
+                "images": ("IMAGE", {"forceInput": True}),
+                "imgbb_api_key": ("STRING", {"default": ""}),
+                "conversation_rounds": ("INT", {"default": 100, "min": 1, "max": 10000, "step": 1}),
+                "historical_record": (_history_choices(), {"default": ""}),
+                "is_enable": ("BOOLEAN", {"default": True}),
+                "extra_parameters": ("DICT", {"forceInput": True}),
+                "user_history": ("STRING", {"forceInput": True}),
+                "img_URL": ("STRING", {"forceInput": True}),
+                "stream": ("BOOLEAN", {"default": False}),
+                "pipeline_first_run": (["使用原始用户提示词", "输出空字符串"],),
+                "pipeline_reset": ("INT", {"default": 0, "min": 0, "max": 999999, "step": 1}),
+                "pipeline_namespace": ("STRING", {"default": "default"}),
+            },
+            "hidden": {"unique_id": "UNIQUE_ID"},
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "STRING", "IMAGE", "STRING", "STRING")
+    RETURN_NAMES = (
+        "assistant_response",
+        "history",
+        "tool",
+        "image",
+        "reasoning_content",
+        "pipeline_status",
+    )
+    FUNCTION = "chatbot"
+    CATEGORY = "大模型派对（llm_party）/模型链（model_chain）"
+    DESCRIPTION = "完整复用 API LLM 通用链路，本轮输出上一轮结果并在后台生成下一轮。"
+    OUTPUT_NODE = True
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return float("NaN")
+
+    def chatbot(
+        self,
+        user_prompt,
+        main_brain,
+        system_prompt,
+        model,
+        temperature,
+        is_memory,
+        is_tools_in_sys_prompt,
+        is_locked,
+        max_length,
+        system_prompt_input="",
+        user_prompt_input="",
+        tools=None,
+        file_content=None,
+        images=None,
+        imgbb_api_key=None,
+        conversation_rounds=100,
+        historical_record="",
+        is_enable=True,
+        extra_parameters=None,
+        user_history=None,
+        img_URL=None,
+        stream=False,
+        pipeline_first_run="使用原始用户提示词",
+        pipeline_reset=0,
+        pipeline_namespace="default",
+        unique_id=None,
+    ):
+        if not is_enable:
+            return (None, None, None, None, "", "Pipeline 已禁用")
+
+        node_key = unique_id if unique_id is not None else id(self)
+        state_key = f"{str(pipeline_namespace or 'default').strip()}:{node_key}"
+        pipeline_reset = int(pipeline_reset or 0)
+        payload = {
+            "user_prompt": user_prompt,
+            "main_brain": main_brain,
+            "system_prompt": system_prompt,
+            "model": model,
+            "temperature": temperature,
+            "is_memory": is_memory,
+            "is_tools_in_sys_prompt": is_tools_in_sys_prompt,
+            "is_locked": is_locked,
+            "max_length": max_length,
+            "system_prompt_input": system_prompt_input,
+            "user_prompt_input": user_prompt_input,
+            "tools": tools,
+            "file_content": file_content,
+            "images": _clone_images_to_cpu(images),
+            "imgbb_api_key": imgbb_api_key,
+            "conversation_rounds": conversation_rounds,
+            "historical_record": historical_record,
+            "is_enable": is_enable,
+            "extra_parameters": extra_parameters,
+            "user_history": user_history,
+            "img_URL": img_URL,
+            "stream": stream,
+        }
+
+        should_start = False
+        with _LOCK:
+            state = _STATES.get(state_key)
+            if state is None:
+                state = _new_state(pipeline_reset)
+                _STATES[state_key] = state
+            elif state["last_reset"] != pipeline_reset:
+                state["version"] += 1
+                state["ready"] = None
+                state["ready_seq"] = 0
+                state["pending"] = None
+                state["delegate"] = None
+                state["error"] = ""
+                state["last_reset"] = pipeline_reset
+
+            ready = state["ready"]
+            ready_seq = state["ready_seq"]
+            previous_error = state["error"]
+            was_running = state["running"]
+            state["pending"] = payload
+            if not state["running"]:
+                state["running"] = True
+                should_start = True
+
+        if should_start:
+            _start_worker(state_key)
+
+        if ready is not None:
+            response, history, tool, image, reasoning = ready
+            status = f"本轮使用缓存 #{ready_seq}；"
+        else:
+            combined_user = str(user_prompt or "") + str(user_prompt_input or "")
+            response = combined_user if pipeline_first_run == "使用原始用户提示词" else ""
+            combined_system = str(system_prompt or "") + str(system_prompt_input or "")
+            history = json.dumps([{"role": "system", "content": combined_system}], ensure_ascii=False)
+            tool, image, reasoning = "", None, ""
+            status = "预热中；"
+
+        status += "后台请求运行中" if was_running else "已提交下一条后台请求"
+        if previous_error:
+            status += f"；上次错误：{previous_error}"
+        return response, history, tool, image, reasoning, status
+
+
+NODE_CLASS_MAPPINGS = {"LLMPartyPipeline": LLMPartyPipeline}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "LLMPartyPipeline": "☁️API LLM Pipeline（上一轮输出）"
+}

--- a/llm.py
+++ b/llm.py
@@ -150,7 +150,6 @@ from .tools.wikipedia import get_wikipedia, load_wikipedia, wikipedia_tool
 from .tools.workflow import work_flow, workflow_tool, workflow_transfer
 from .tools.flux_persona import flux_persona
 from .tools.workflow_V2 import workflow_transfer_v2
-os.environ["no_proxy"] = "localhost,127.0.0.1"
 enable_interpreter = True
 
 _TOOL_HOOKS = [

--- a/llm.py
+++ b/llm.py
@@ -134,6 +134,9 @@ from .tools.search_web import (
     duckduckgo_tool,
     duckduckgo_loader,
     search_duckduckgo,
+    tavily_tool,
+    tavily_loader,
+    search_web_tavily,
 )
 from .tools.show_text import About_us, show_text_party
 from .tools.smalltool import bool_logic, load_int, none2false,str2float,str2int,any2str,load_float,load_bool
@@ -192,6 +195,7 @@ _TOOL_HOOKS = [
     "Inquire_entity_relationships_neo4j",
     "Inquire_entity_list_neo4j",
     "search_duckduckgo",
+    "search_web_tavily",
 ]
 if enable_interpreter:
     _TOOL_HOOKS.append("interpreter")
@@ -3067,6 +3071,8 @@ NODE_CLASS_MAPPINGS = {
     "bool_logic": bool_logic,
     "duckduckgo_tool":duckduckgo_tool,
     "duckduckgo_loader":duckduckgo_loader,
+    "tavily_tool":tavily_tool,
+    "tavily_loader":tavily_loader,
     "flux_persona":flux_persona,
     "clear_file":clear_file,
     "workflow_transfer_v2":workflow_transfer_v2,
@@ -3189,6 +3195,8 @@ if lang == "zh_CN":
         "bool_logic": "布尔逻辑",
         "duckduckgo_tool": "DuckDuckGo工具",
         "duckduckgo_loader": "DuckDuckGo加载器",
+        "tavily_tool": "Tavily搜索工具",
+        "tavily_loader": "Tavily搜索加载器",
         "flux_persona":"flux提示词生成器面具",
         "clear_file":"清理文件",
         "workflow_transfer_v2":"工作流中转器V2",
@@ -3305,6 +3313,8 @@ else:
         "bool_logic": "Boolean Logic",
         "duckduckgo_tool": "DuckDuckGo Tool",
         "duckduckgo_loader":"DuckDuckGo Loader",
+        "tavily_tool": "Tavily Search Tool",
+        "tavily_loader": "Tavily Search Loader",
         "flux_persona":"flux prompt word generator",
         "clear_file":"clear file",
         "workflow_transfer_v2": "Workflow Transfer V2",

--- a/llm.py
+++ b/llm.py
@@ -670,6 +670,7 @@ class Chat:
                                 ],
                                 "role": "assistant",
                                 "content": str(response_content),
+                                **({"reasoning_content": reasoning_content} if reasoning_content else {}),
                             }
                         )
                         history.append(
@@ -735,6 +736,7 @@ class Chat:
                                 ],
                                 "role": "assistant",
                                 "content": str(response_content),
+                                **({"reasoning_content": getattr(assistant_message, 'reasoning_content', '')} if getattr(assistant_message, 'reasoning_content', '') else {}),
                             }
                         )
                         history.append(
@@ -834,7 +836,11 @@ class Chat:
             if match:
                 reasoning_content = match.group(1).strip()
                 response_content = response_content.replace(match.group(0), "").strip() 
-            history.append({"role": "assistant", "content": response_content})
+            # 思考模式的 reasoning_content 必须随 assistant 消息原样带回，否则 DeepSeek 等 API 会报 400
+            if reasoning_content:
+                history.append({"role": "assistant", "content": response_content, "reasoning_content": reasoning_content})
+            else:
+                history.append({"role": "assistant", "content": response_content})
         except Exception as ex:
             response_content = str(ex)
             reasoning_content = str(ex)
@@ -1041,6 +1047,7 @@ class aisuite_Chat:
                                 ],
                                 "role": "assistant",
                                 "content": str(response_content),
+                                **({"reasoning_content": reasoning_content} if reasoning_content else {}),
                             }
                         )
                         history.append(
@@ -1106,6 +1113,7 @@ class aisuite_Chat:
                                 ],
                                 "role": "assistant",
                                 "content": str(response_content),
+                                **({"reasoning_content": getattr(assistant_message, 'reasoning_content', '')} if getattr(assistant_message, 'reasoning_content', '') else {}),
                             }
                         )
                         history.append(
@@ -1204,7 +1212,11 @@ class aisuite_Chat:
             if match:
                 reasoning_content = match.group(1).strip()
                 response_content = response_content.replace(match.group(0), "").strip() 
-            history.append({"role": "assistant", "content": response_content})
+            # 思考模式的 reasoning_content 必须随 assistant 消息原样带回，否则 DeepSeek 等 API 会报 400
+            if reasoning_content:
+                history.append({"role": "assistant", "content": response_content, "reasoning_content": reasoning_content})
+            else:
+                history.append({"role": "assistant", "content": response_content})
         except Exception as ex:
             response_content = str(ex)
             reasoning_content = str(ex)

--- a/test/test_pipeline_llm.py
+++ b/test/test_pipeline_llm.py
@@ -1,0 +1,107 @@
+import importlib.util
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+PATH = Path(__file__).resolve().parents[1] / "custom_tool" / "pipeline_llm.py"
+SPEC = importlib.util.spec_from_file_location("pipeline_llm_under_test", PATH)
+pipeline = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(pipeline)
+
+
+class FakeDelegate:
+    def __init__(self, block=None, calls=None):
+        self.block = block
+        self.calls = calls if calls is not None else []
+
+    def chatbot(self, **kwargs):
+        value = str(kwargs["user_prompt"])
+        self.calls.append(kwargs)
+        if self.block and value == "one":
+            self.block[0].set()
+            self.block[1].wait(1.0)
+        return ("generated:" + value, "history:" + value, "tools", None, "reasoning")
+
+
+class PipelineTests(unittest.TestCase):
+    def setUp(self):
+        with pipeline._LOCK:
+            pipeline._STATES.clear()
+
+    def tearDown(self):
+        self.wait_idle()
+        with pipeline._LOCK:
+            pipeline._STATES.clear()
+
+    def wait_idle(self):
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            with pipeline._LOCK:
+                if all(not state["running"] for state in pipeline._STATES.values()):
+                    return
+            time.sleep(0.01)
+        self.fail("worker did not stop")
+
+    def test_has_all_general_link_inputs_and_outputs(self):
+        inputs = pipeline.LLMPartyPipeline.INPUT_TYPES()
+        required = {
+            "system_prompt", "user_prompt", "model", "temperature", "is_memory",
+            "is_tools_in_sys_prompt", "is_locked", "main_brain", "max_length",
+        }
+        optional = {
+            "system_prompt_input", "user_prompt_input", "tools", "file_content",
+            "images", "imgbb_api_key", "conversation_rounds", "historical_record",
+            "is_enable", "extra_parameters", "user_history", "img_URL", "stream",
+        }
+        self.assertTrue(required.issubset(inputs["required"]))
+        self.assertTrue(optional.issubset(inputs["optional"]))
+        self.assertEqual(pipeline.LLMPartyPipeline.RETURN_NAMES[:5], (
+            "assistant_response", "history", "tool", "image", "reasoning_content"
+        ))
+
+    def test_next_run_uses_previous_full_result(self):
+        delegate = FakeDelegate()
+        pipeline._create_delegate = lambda _model: delegate
+        node = pipeline.LLMPartyPipeline()
+        first = node.chatbot("first", "enable", "sys", object(), 0.7, "disable", "disable", "disable", 1920, unique_id="1")
+        self.assertEqual(first[0], "first")
+        self.wait_idle()
+        second = node.chatbot("second", "enable", "sys", object(), 0.7, "disable", "disable", "disable", 1920, unique_id="1")
+        self.assertEqual(second[:5], ("generated:first", "history:first", "tools", None, "reasoning"))
+
+    def test_only_latest_pending_input_is_kept(self):
+        started, release = threading.Event(), threading.Event()
+        calls = []
+        delegate = FakeDelegate((started, release), calls)
+        pipeline._create_delegate = lambda _model: delegate
+        node = pipeline.LLMPartyPipeline()
+        args = ("enable", "sys", object(), 0.7, "disable", "disable", "disable", 1920)
+        node.chatbot("one", *args, unique_id="2")
+        self.assertTrue(started.wait(1.0))
+        node.chatbot("two", *args, unique_id="2")
+        node.chatbot("three", *args, unique_id="2")
+        release.set()
+        self.wait_idle()
+        self.assertEqual([call["user_prompt"] for call in calls], ["one", "three"])
+
+    def test_empty_final_answer_keeps_previous_result(self):
+        good = FakeDelegate()
+        pipeline._create_delegate = lambda _model: good
+        node = pipeline.LLMPartyPipeline()
+        args = ("enable", "sys", object(), 0.7, "disable", "disable", "disable", 1920)
+        node.chatbot("good", *args, unique_id="3")
+        self.wait_idle()
+
+        good.chatbot = lambda **_kwargs: ("", "new history", "tools", None, "reasoning only")
+        output = node.chatbot("bad", *args, unique_id="3")
+        self.assertEqual(output[0], "generated:good")
+        self.wait_idle()
+        with pipeline._LOCK:
+            self.assertEqual(pipeline._STATES["default:3"]["ready"][0], "generated:good")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/search_web.py
+++ b/tools/search_web.py
@@ -484,3 +484,131 @@ class duckduckgo_loader:
         ddg_searchType = searchType
         out = search_duckduckgo(keywords, paper_num)
         return (out,)
+
+
+# ============ Tavily API 搜索（独立节点，2026-08-12 新增，与 duckduckgo 无关） ============
+# Tavily 是商业搜索 API（api.tavily.com），返回结构化 JSON，无爬虫反爬问题。
+# key 从 config.ini [API_KEYS] tavily_api_key 读取（模块加载时读取，改完需重启 ComfyUI）。
+# 支持中英文；offset 实测 0-10 有效（第 2 页），超出范围 Tavily 静默返回第 1 页。
+tavily_api_key = api_keys.get("tavily_api_key")
+
+
+def search_web_tavily(keywords, paper_num=1):
+    if paper_num == "":
+        paper_num = 1
+    today = str(date.today())
+    num_results = 10
+    offset = num_results * (int(paper_num) - 1)
+    query = keywords if isinstance(keywords, str) else " ".join(keywords)
+    try:
+        payload = {
+            "api_key": tavily_api_key,
+            "query": query,
+            "search_depth": "basic",
+            "max_results": num_results,
+            "offset": offset,
+        }
+        resp = requests.post(
+            "https://api.tavily.com/search",
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            proxies=PROXIES,
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return f"搜索失败：Tavily HTTP {resp.status_code}: {resp.text[:200]}"
+        data = resp.json()
+        results = data.get("results") or []
+        all_content = ""
+        for item in results:
+            all_content += "\n\n" + json.dumps(
+                {
+                    "title": item.get("title", ""),
+                    "link": item.get("url", ""),
+                    "snippet": item.get("content", ""),
+                },
+                ensure_ascii=False,
+                indent=4,
+            )
+    except Exception as e:
+        return f"Exception occurred: {e}"
+
+    if not all_content.strip():
+        return f"今天的日期是{today}，搜索关键词“{query}”没有返回任何结果。"
+    print(all_content)
+    return (
+        "今天的日期是"
+        + today
+        + "，当前网络的信息和信息来源的网址为：“"
+        + str(all_content)
+        + "”。\n如果以上信息中没有相关信息，你可以改变paper_num，查看下一页的信息。"
+    )
+
+
+class tavily_tool:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "is_enable": ("BOOLEAN", {"default": True}),
+            },
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("tool",)
+
+    FUNCTION = "web"
+
+    CATEGORY = "大模型派对（llm_party）/工具（tools）/联网（Networking）"
+
+    def web(self, is_enable=True):
+        if is_enable == False:
+            return (None,)
+        output = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_web_tavily",
+                    "description": "通过关键词获得网络搜索信息（支持中英文，无需代理直连限制）。搜索技巧：①关键词要简短，多个概念要拆开多次调用；②动漫/游戏角色资料优先使用英文名（Danbooru 标准名，如 Corsola），效果最精准；中文名次之（如 希娜狄雅）；不要用罗马音（如 senadina 可，但 niwatari kutaka 搜不到）；③不确定原名时先用作品名+中文描述搜一次。",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "keywords": {
+                                "type": "string",
+                                "description": "需要搜索的关键词，简短准确；动漫/游戏角色优先英文名（Danbooru 名），其次中文名，不要用罗马音。",
+                            },
+                            "paper_num": {"type": "string", "description": "搜索的页码，可以改变paper_num用于翻页"},
+                        },
+                        "required": ["keywords", "paper_num"],
+                    },
+                },
+            }
+        ]
+
+        out = json.dumps(output, ensure_ascii=False)
+        return (out,)
+
+
+class tavily_loader:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "is_enable": ("BOOLEAN", {"default": True}),
+                "keywords": ("STRING", {}),
+                "paper_num": ("INT", {"default": 1}),
+            },
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("text",)
+
+    FUNCTION = "web"
+
+    CATEGORY = "大模型派对（llm_party）/知识库（knowbase）"
+
+    def web(self, keywords, paper_num=1, is_enable=True):
+        if is_enable == False:
+            return (None,)
+        out = search_web_tavily(keywords, paper_num)
+        return (out,)

--- a/tools/search_web.py
+++ b/tools/search_web.py
@@ -353,6 +353,7 @@ class bing_loader:
 
 ddg_searchType = "web"
 
+
 def search_duckduckgo(keywords, paper_num=1):
     if paper_num == "":
         paper_num = 1
@@ -380,7 +381,8 @@ def search_duckduckgo(keywords, paper_num=1):
 
         data = response.json()
         all_content = ""
-        if response.status_code == 200:
+        # DDG 的 Instant Answer API 对很多查询返回 202（含有效结果），仅 200 会误判为失败
+        if response.status_code in (200, 202):
             if "RelatedTopics" in data:
                 for item in data["RelatedTopics"]:
                     if "Text" in item and "FirstURL" in item:

--- a/tools/search_web.py
+++ b/tools/search_web.py
@@ -512,7 +512,6 @@ def search_web_tavily(keywords, paper_num=1):
             "https://api.tavily.com/search",
             json=payload,
             headers={"Content-Type": "application/json"},
-            proxies=PROXIES,
             timeout=15,
         )
         if resp.status_code != 200:


### PR DESCRIPTION
三个改动：① 新增基于 Tavily API 的搜索节点；② 新增异步 LLM Pipeline 节点；③ 修复 DeepSeek 等思考模式模型多轮对话 400 错误。

改动内容

1. Tavily 搜索节点（tavily_tool / tavily_loader）

改动：
- tools/search_web.py：新增 search_web_tavily() 函数 + tavily_tool / tavily_loader 节点类
  - POST https://api.tavily.com/search，参数 {api_key, query, search_depth, max_results, offset}
  - 支持分页（paper_num → offset）
  - API key 从 config.ini [API_KEYS] tavily_api_key 读取，不硬编码
- llm.py：注册节点（import、_TOOL_HOOKS 白名单、NODE_CLASS_MAPPINGS、中英文显示名）

使用方式：在 config.ini 填入 tavily_api_key（Tavily 官网免费注册，1000 次/月额度），节点出现在"大模型派对（llm_party）/工具（tools）/联网（Networking）"和"知识库（knowbase）"分类。

2. 异步 LLM Pipeline 节点（LLMPartyPipeline）

背景：LLM 节点同步阻塞导致 ComfyUI 工作流排队时界面卡顿，长回复（如长文生成）期间无法继续操作。

改动：
- custom_tool/pipeline_llm.py：新增 LLMPartyPipeline 节点
  - 后台线程异步执行 LLM 节点，队列不阻塞
  - 状态缓存按 namespace:node_id 区分，支持多实例并行
  - 保留 extra_parameters 透传能力
- custom_tool/README_pipeline.md：使用文档
- test/test_pipeline_llm.py：单元测试

3. 修复 DeepSeek 思考模式多轮对话 400 错误

背景：使用带 reasoning 的模型（如 DeepSeek R1 / 思考模式）时，assistant 历史消息必须原样携带 reasoning_content 字段，否则后续请求返回 400。

改动（llm.py）：
- Chat 和 aisuite_Chat 的 assistant 历史消息补充 reasoning_content 字段（函数调用分支、对象消息分支、思考内容剥离分支共 6 处）