### PR TITLE
docs: fix broken star history chart in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ Some of the nodes in this project have borrowed from the following projects. Tha
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_AR.md
+++ b/README_AR.md
@@ -192,4 +192,4 @@ ComfyUI LLM Party، من أبسط استدعاءات أدوات LLM المتعد
 
 ## تاريخ النجوم
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_DE.md
+++ b/README_DE.md
@@ -191,4 +191,4 @@ Einige Knoten in diesem Projekt basieren auf den folgenden Projekten. Wir danken
 
 ## Sternenverlauf
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_ES.md
+++ b/README_ES.md
@@ -191,4 +191,4 @@ Algunos nodos en este proyecto se han inspirado en los siguientes proyectos. ¡A
 
 ## Historial de estrellas
 
-[![Gráfico de Historial de Estrellas](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Gráfico de Historial de Estrellas](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_FR.md
+++ b/README_FR.md
@@ -191,4 +191,4 @@ Certaines des fonctionnalités de ce projet s'inspirent des projets suivants, no
 
 ## Historique des étoiles
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_JA.md
+++ b/README_JA.md
@@ -192,4 +192,4 @@ ComfyUI LLM Partyは、最も基本的なLLMの多ツール呼び出しやキャ
 
 ## スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_KO.md
+++ b/README_KO.md
@@ -192,4 +192,4 @@ ComfyUI LLM Party는 가장 기본적인 LLM 다중 도구 호출, 역할 설정
 
 ## 스타 기록
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_PT.md
+++ b/README_PT.md
@@ -191,4 +191,4 @@ Alguns nós deste projeto foram inspirados pelos seguintes projetos, agradecemos
 
 ## Histórico de Estrelas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_RU.md
+++ b/README_RU.md
@@ -191,4 +191,4 @@ ComfyUI LLM Party предлагает от самых основ LLM, вклю�
 
 ## История звёзд
 
-[![График истории звёзд](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![График истории звёзд](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -196,4 +196,4 @@ ComfyUI LLM Party，从最基础的 LLM 多工具调用、角色设定快速搭�
 
 ## 星标历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/file/README.md
+++ b/file/README.md
@@ -276,4 +276,4 @@ If my work has brought value to your day, consider fueling it with a coffee! You
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)

--- a/file/README_ZH.md
+++ b/file/README_ZH.md
@@ -276,4 +276,4 @@ ComfyUI LLM Party，从最基础的 LLM 多工具调用、角色设定快速搭�
 
 ## 星标历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.com/#heshengtao/comfyui_LLM_party&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heshengtao/comfyui_LLM_party&type=Date)](https://star-history.dera.page/#heshengtao/comfyui_LLM_party&Date)


### PR DESCRIPTION
The star history chart shown in the README (and all localized READMEs) is currently broken and no longer renders. This PR updates the chart to use a working source so the star history is visible again for everyone visiting the repository.

Changed files:
- README.md
- README_ZH.md, README_AR.md, README_DE.md, README_ES.md, README_FR.md, README_JA.md, README_KO.md, README_PT.md, README_RU.md
- file/README.md, file/README_ZH.md