### PR TITLE
feat: 支持 OpenAI/Azure OpenAI 请求响应 ComfyUI 中断与取消

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -36,7 +36,7 @@ from transformers import (
     AutoConfig,
 )
 import PIL.Image
-from openai import AzureOpenAI,OpenAI
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 if torch.cuda.is_available():
     from transformers import BitsAndBytesConfig
 from google.protobuf.struct_pb2 import Struct
@@ -414,14 +414,49 @@ def interruptible_stream(stream):
         yield chunk
 
 
+async def _create_openai_chat_completion(async_client, normalized):
+    request_task = asyncio.create_task(
+        async_client.chat.completions.create(**normalized)
+    )
+    try:
+        while not request_task.done():
+            throw_exception_if_processing_interrupted()
+            await asyncio.sleep(0.05)
+        return await request_task
+    except BaseException:
+        if not request_task.done():
+            request_task.cancel()
+            await asyncio.gather(request_task, return_exceptions=True)
+        raise
+    finally:
+        await async_client.close()
+
+
 def create_openai_chat_completion(openai_client, **kwargs):
-    # check for interrupt first
     throw_exception_if_processing_interrupted()
     normalized = normalize_openai_chat_kwargs(kwargs)
-    response = openai_client.chat.completions.create(**normalized)
+
+    # Keep the existing synchronous iterator contract for streaming callers.
     if normalized.get("stream", False):
-        return interruptible_stream(response)  # for stream mode
-    throw_exception_if_processing_interrupted()  # for non-stream mode, check after response is received
+        response = openai_client.chat.completions.create(**normalized)
+        return interruptible_stream(response)
+
+    if isinstance(openai_client, AzureOpenAI):
+        async_client = AsyncAzureOpenAI(
+            api_key=openai_client.api_key,
+            api_version=openai_client._api_version,
+            azure_endpoint=str(openai_client._azure_endpoint),
+        )
+    else:
+        async_client = AsyncOpenAI(
+            api_key=openai_client.api_key,
+            base_url=str(openai_client.base_url),
+        )
+
+    response = asyncio.run(
+        _create_openai_chat_completion(async_client, normalized)
+    )
+    throw_exception_if_processing_interrupted()
     return response
 
 async def get_models_list(api_key: str, base_url: str) -> tuple[list[str], int | None]:

--- a/llm.py
+++ b/llm.py
@@ -17,6 +17,7 @@ import time
 import traceback
 from aiohttp import web
 from comfy_api.latest import io as comfy_io
+from comfy.model_management import throw_exception_if_processing_interrupted
 from server import PromptServer
 # import google.generativeai as genai
 import numpy as np
@@ -406,8 +407,22 @@ def normalize_openai_chat_kwargs(kwargs):
     return normalized
 
 
+def interruptible_stream(stream):
+    """throw InterruptProcessingException if ComfyUI processing is interrupted during streaming."""
+    for chunk in stream:
+        throw_exception_if_processing_interrupted()
+        yield chunk
+
+
 def create_openai_chat_completion(openai_client, **kwargs):
-    return openai_client.chat.completions.create(**normalize_openai_chat_kwargs(kwargs))
+    # check for interrupt first
+    throw_exception_if_processing_interrupted()
+    normalized = normalize_openai_chat_kwargs(kwargs)
+    response = openai_client.chat.completions.create(**normalized)
+    if normalized.get("stream", False):
+        return interruptible_stream(response)  # for stream mode
+    throw_exception_if_processing_interrupted()  # for non-stream mode, check after response is received
+    return response
 
 async def get_models_list(api_key: str, base_url: str) -> tuple[list[str], int | None]:
     """


### PR DESCRIPTION
## 概述

本次改动聚焦于 `create_openai_chat_completion`，让 API 调用能够正确响应 ComfyUI 的处理中断，并在非流式请求中支持干净地取消正在进行的任务。

## 改动内容

- **请求前/后中断检查**：在发起请求前以及拿到响应后都会调用 `throw_exception_if_processing_interrupted()`，保证生成流程在中断信号触发时及时停止。
- **流式请求（stream）**：保留原有的同步迭代器契约，新增 `interruptible_stream`，在逐块消费响应时检查中断状态。
- **非流式请求**：新增 `_create_openai_chat_completion`，通过 `asyncio.create_task` 以异步方式发起请求，在等待期间轮询中断信号；收到中断时取消任务并等待其真正结束，避免后台请求悬挂；最后关闭异步客户端，释放连接资源。
- **客户端适配**：同时支持 OpenAI（`AsyncOpenAI`）与 Azure OpenAI（`AsyncAzureOpenAI`），从现有同步客户端读取 API Key、版本和端点信息构造异步客户端。

## 影响范围

- 涉及文件：`llm.py`
- 两个提交：
  - `e0dcb59` Preserve interruptible OpenAI completion handling
  - `6eb8efd` Update llm.py（引入异步取消支持）
