### PR TITLE
fix(amap): 天气/逆地理编码节点每次执行都抛 TypeError（多传了 api_key）

### DIFF
--- a/custom_tool/amap.py
+++ b/custom_tool/amap.py
@@ -40,7 +40,7 @@ class AmapWeatherTool:
             return (None,)
         global amap_api_key
         amap_api_key = api_key
-        weather_info = get_amap_weather(city_code, api_key)
+        weather_info = get_amap_weather(city_code)
         if weather_info:
             output = [
                 {

--- a/custom_tool/amap_decode.py
+++ b/custom_tool/amap_decode.py
@@ -44,7 +44,7 @@ class AmapRegeoTool:
             return (None,)
         global amap_api_key
         amap_api_key = api_key
-        regeo_info = get_amap_regeo(location, api_key, extensions, radius)
+        regeo_info = get_amap_regeo(location, extensions, radius)
         if regeo_info:
             output = [
                 {


### PR DESCRIPTION
### 问题 / What

高德（AMap）的两个工具节点在执行时必定抛 `TypeError`：

| 节点 | 调用 | 定义 | 结果 |
|---|---|---|---|
| `WeatherTool` (`custom_tool/amap.py:43`) | `get_amap_weather(city_code, api_key)` | `def get_amap_weather(city_code)` | `takes 1 positional argument but 2 were given` |
| `RegeoTool` (`custom_tool/amap_decode.py:47`) | `get_amap_regeo(location, api_key, extensions, radius)` | `def get_amap_regeo(location, extensions="all", radius=1000)` | `takes from 1 to 3 positional arguments but 4 were given` |

两个 helper 都是从模块级全局 `amap_api_key` 取 key 的：

```python
def get_amap_weather(city_code):
    global amap_api_key
    ...
    params = {'key': amap_api_key, ...}
```

而节点在调用的**上一行**就已经把它设好了：

```python
        global amap_api_key
        amap_api_key = api_key
        weather_info = get_amap_weather(city_code, api_key)   # <- 这个 api_key 是多余的
```

### 为什么确定是调用点写错、而不是 helper 少了参数

同目录第三个高德工具 `custom_tool/amap_encode.py` 的 `GeocodeTool` 就是按设计写的 —— 设置全局，然后**不**把 key 传进去：

```python
amap_api_key = ""
def geocode(address):
    global amap_api_key
    url = f"...&key={amap_api_key}"
...
        amap_api_key = api_key
        # 不传 api_key
```

三个同族模块，一个正确、两个错误，所以这里按正确的那个对齐，只删掉多余的实参。

### 验证 / Verification

用 `inspect.Signature.bind` 静态重放两个调用点（AST 取真实签名建 stub）：

Before:
```
custom_tool/amap.py        get_amap_weather (city_code)
   line 43 FAIL -> TypeError: too many positional arguments
custom_tool/amap_decode.py get_amap_regeo (location, extensions=None, radius=None)
   line 47 FAIL -> TypeError: too many positional arguments
```

打上本补丁后两处都能正常 bind。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
